### PR TITLE
configure-aws-credentials-actionsをv1からv2へアップデート

### DIFF
--- a/.github/workflows/S3-Lambda-deploy-workflow.yml
+++ b/.github/workflows/S3-Lambda-deploy-workflow.yml
@@ -17,7 +17,7 @@ jobs:
          uses: actions/checkout@v3
 
        - name: Configure AWS Credentials
-         uses: aws-actions/configure-aws-credentials@v1
+         uses: aws-actions/configure-aws-credentials@v2
          with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -71,7 +71,7 @@ jobs:
         run: zipinfo lambda_function.zip
         
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -92,7 +92,7 @@ jobs:
           python-version: 3.9
       
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/create-and-store-graph-workflow.yml
+++ b/.github/workflows/create-and-store-graph-workflow.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/verify-access_token-workflow.yml
+++ b/.github/workflows/verify-access_token-workflow.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
       
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
# Actionsの実行結果より警告がでていた。。
<img width="657" alt="image" src="https://github.com/Level-up-geek/LineBot/assets/82359371/62cf58d1-75e6-4284-9352-babcd878175f">

よって、バージョンアップをする。
# 公式ドキュメント
公式ドキュメントを読んだ感じ、v1と書き方が変わっているという訳でもなさそうだったのでただv1からv2に書き換えるだけにした
https://github.com/marketplace/actions/configure-aws-credentials-for-github-actions?version=v2