### PR TITLE
ワークフロー上でset-outputを使っている箇所を$GITHUB_OUTPUTを使うように更新する

### DIFF
--- a/.github/actions/download-s3-object-action/action.yml
+++ b/.github/actions/download-s3-object-action/action.yml
@@ -23,5 +23,5 @@ runs:
     - id: download-s3-object
       run: |
         downloaded_access_token=$(cat ./access_token.josn | tr -d '\n')
-        echo "::set-output name=s3-object::$(echo $downloaded_access_token | jq -r -R 'fromjson? | ${{ inputs.key }}')"
+        echo "s3-object=$(echo $downloaded_access_token | jq -r -R 'fromjson? | ${{ inputs.key }}')" >> $GITHUB_OUTPUT
       shell: bash


### PR DESCRIPTION
# Actionsの実行結果を見たら警告がでていた。。
この警告はめっちゃありがたい。
<img width="657" alt="image" src="https://github.com/Level-up-geek/LineBot/assets/82359371/5576f673-8449-4c21-ac6a-52dde2aa8ac8">

# 公式ドキュメントによると
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

下記のように書き換えるだけでよいらしく、簡単に修正できそうなのでやっちゃう。
```yml
- name: Save state
run: echo "{name}={value}" >> $GITHUB_STATE

- name: Set output
run: echo "{name}={value}" >> $GITHUB_OUTPUT
```
